### PR TITLE
Fix cargo manager slot handling

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,6 @@
 // Add your dependencies here
 
 dependencies {
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev")
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -50,16 +50,19 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = vswe.stevescarts.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = StevesCarts.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/vswe/stevescarts/Helpers/CargoItemSelection.java
+++ b/src/main/java/vswe/stevescarts/Helpers/CargoItemSelection.java
@@ -4,17 +4,17 @@ import net.minecraft.item.ItemStack;
 
 public class CargoItemSelection {
 
-    private Class validSlot;
+    private Class<?> validSlot;
     private ItemStack icon;
     private Localization.GUI.CARGO name;
 
-    public CargoItemSelection(Localization.GUI.CARGO name, Class validSlot, ItemStack icon) {
+    public CargoItemSelection(Localization.GUI.CARGO name, Class<?> validSlot, ItemStack icon) {
         this.name = name;
         this.validSlot = validSlot;
         this.icon = icon;
     }
 
-    public Class getValidSlot() {
+    public Class<?> getValidSlot() {
         return validSlot;
     }
 

--- a/src/main/java/vswe/stevescarts/Helpers/TransferHandler.java
+++ b/src/main/java/vswe/stevescarts/Helpers/TransferHandler.java
@@ -16,7 +16,7 @@ public class TransferHandler {
         OTHER
     }
 
-    public static boolean isSlotOfType(Slot slot, java.lang.Class slotType) {
+    public static boolean isSlotOfType(Slot slot, Class<?> slotType) {
         if (slot instanceof ISpecialSlotValidator) {
             ISpecialSlotValidator specSlot = (ISpecialSlotValidator) slot;
             return specSlot.isSlotValid();
@@ -43,18 +43,18 @@ public class TransferHandler {
         TransferItem(iStack, inv, 0, inv.getSizeInventory() - 1, cont, validSlot, null, maxItems, type, false);
     }
 
-    public static void TransferItem(ItemStack iStack, IInventory inv, Container cont, java.lang.Class validSlot,
-            java.lang.Class invalidSlot, int maxItems) {
+    public static void TransferItem(ItemStack iStack, IInventory inv, Container cont, Class<?> validSlot,
+            Class<?> invalidSlot, int maxItems) {
         TransferItem(iStack, inv, 0, inv.getSizeInventory() - 1, cont, validSlot, invalidSlot, maxItems);
     }
 
     public static void TransferItem(ItemStack iStack, IInventory inv, int start, int end, Container cont,
-            java.lang.Class validSlot, java.lang.Class invalidSlot, int maxItems) {
+            Class<?> validSlot, Class<?> invalidSlot, int maxItems) {
         TransferItem(iStack, inv, start, end, cont, validSlot, invalidSlot, maxItems, TRANSFER_TYPE.OTHER, false);
     }
 
     public static void TransferItem(ItemStack iStack, IInventory inv, int start, int end, Container cont,
-            java.lang.Class validSlot, java.lang.Class invalidSlot, int maxItems, TRANSFER_TYPE type, boolean fake) {
+            Class<?> validSlot, Class<?> invalidSlot, int maxItems, TRANSFER_TYPE type, boolean fake) {
         start = Math.max(0, start);
         end = Math.min(inv.getSizeInventory() - 1, end);
 

--- a/src/main/java/vswe/stevescarts/Slots/SlotFake.java
+++ b/src/main/java/vswe/stevescarts/Slots/SlotFake.java
@@ -6,7 +6,7 @@ import net.minecraft.item.ItemStack;
 
 import vswe.stevescarts.Helpers.TransferHandler.TRANSFER_TYPE;
 
-public abstract class SlotFake extends SlotBase implements ISpecialItemTransferValidator {
+public abstract class SlotFake extends SlotBase implements ISpecialItemTransferValidator, ISpecialSlotValidator {
 
     public SlotFake(IInventory iinventory, int i, int j, int k) {
         super(iinventory, i, j, k);
@@ -27,6 +27,11 @@ public abstract class SlotFake extends SlotBase implements ISpecialItemTransferV
 
     @Override
     public boolean isItemValidForTransfer(ItemStack item, TRANSFER_TYPE type) {
+        return false;
+    }
+
+    @Override
+    public boolean isSlotValid() {
         return false;
     }
 

--- a/src/main/java/vswe/stevescarts/StevesCarts.java
+++ b/src/main/java/vswe/stevescarts/StevesCarts.java
@@ -37,7 +37,7 @@ import vswe.stevescarts.Listeners.TicketListener;
 import vswe.stevescarts.TileEntities.TileEntityCargo;
 import vswe.stevescarts.Upgrades.AssemblerUpgrade;
 
-@Mod(modid = "StevesCarts", name = "Steve's Carts 2", version = "GRADLETOKEN_VERSION")
+@Mod(modid = "StevesCarts", name = "Steve's Carts 2", version = Tags.VERSION)
 public class StevesCarts {
 
     public static boolean hasGreenScreen = false;

--- a/src/main/java/vswe/stevescarts/TileEntities/TileEntityCargo.java
+++ b/src/main/java/vswe/stevescarts/TileEntities/TileEntityCargo.java
@@ -61,7 +61,7 @@ public class TileEntityCargo extends TileEntityManager {
     public static ArrayList<CargoItemSelection> itemSelections;
 
     public static void loadSelectionSettings() {
-        itemSelections = new ArrayList<CargoItemSelection>();
+        itemSelections = new ArrayList<>();
         itemSelections.add(
                 new CargoItemSelection(
                         Localization.GUI.CARGO.AREA_ALL,
@@ -145,7 +145,7 @@ public class TileEntityCargo extends TileEntityManager {
         return "container.cargomanager";
     }
 
-    public int target[] = new int[] { 0, 0, 0, 0 };
+    public int[] target = new int[] { 0, 0, 0, 0 };
     public ArrayList<SlotCargo> cargoSlots;
     public int lastLayout = -1;
 
@@ -292,19 +292,19 @@ public class TileEntityCargo extends TileEntityManager {
 
     @Override
     protected boolean doTransfer(ManagerTransfer transfer) {
-        java.lang.Class slotCart = itemSelections.get(target[transfer.getSetting()]).getValidSlot();
+        Class<?> slotCart = itemSelections.get(target[transfer.getSetting()]).getValidSlot();
         if (slotCart == null) {
             transfer.setLowestSetting(transfer.getSetting() + 1);
             return true;
         }
-        java.lang.Class slotCargo = SlotCargo.class;
+        Class<?> slotCargo = SlotCargo.class;
 
         IInventory fromInv;
         Container fromCont;
-        java.lang.Class fromValid;
+        Class<?> fromValid;
         IInventory toInv;
         Container toCont;
-        java.lang.Class toValid;
+        Class<?> toValid;
 
         if (toCart[transfer.getSetting()]) {
             fromInv = this;


### PR DESCRIPTION
The transfer method in this mod is unfathomably cursed... This makes it so that method completely ignores any fake slots when inserting/extracting.

Closes: https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/131