### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/stevescarts/lang/en_US.lang
+++ b/src/main/resources/assets/stevescarts/lang/en_US.lang
@@ -412,11 +412,13 @@ tile.SC2:BlockDistributor.name=External Distributor
 tile.SC2:BlockLiquidManager.name=Liquid Manager
 
 # Storage
+tile.SC2:BlockMetalStorage.name=Resource Block
 item.SC2:BlockStorage0.name=Reinforced Metal Block
 item.SC2:BlockStorage1.name=Galgadorian Block
 item.SC2:BlockStorage2.name=Enhanced Galgadorian Block
 
 # Upgrades
+tile.SC2:upgrade.name=Upgrade
 item.SC2:batteries.name=Upgrade: Batteries
 item.SC2:power_crystal.name=Upgrade: Power Crystal
 item.SC2:module_knowledge.name=Upgrade: Module knowledge
@@ -439,6 +441,7 @@ item.SC2:solar_panel_upgrade.name=Upgrade: Solar Panel
 item.SC2:thermal_engine_upgrade.name=Upgrade: Thermal Engine
 
 # Detector Units
+tile.SC2:BlockDetector.name=Detector
 item.SC2:BlockDetector0.name=Detector Manager
 item.SC2:BlockDetector1.name=Detector Unit
 item.SC2:BlockDetector2.name=Detector Station


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.